### PR TITLE
Add Monster System to Dungeon Rooms

### DIFF
--- a/server/src/rooms/Dungeon.ts
+++ b/server/src/rooms/Dungeon.ts
@@ -98,6 +98,17 @@ export class Dungeon extends Room<DungeonState> {
       const result = this.state.confirmCardAction(client.sessionId);
       client.send("confirmCardActionResult", result);
     });
+
+    // Monster system message handlers
+    this.onMessage("claimMonster", (client, { monsterId }) => {
+      const result = this.state.claimMonster(client.sessionId, monsterId);
+      client.send("claimMonsterResult", result);
+    });
+
+    this.onMessage("selectMonsterSquare", (client, { monsterId, x, y }) => {
+      const result = this.state.selectMonsterSquare(client.sessionId, monsterId, x, y);
+      client.send("selectMonsterSquareResult", result);
+    });
   }
 
   onJoin(client: Client, options: any) {

--- a/server/src/rooms/schema/MonsterCard.ts
+++ b/server/src/rooms/schema/MonsterCard.ts
@@ -1,0 +1,55 @@
+import { Schema, type, ArraySchema } from "@colyseus/schema";
+import { MonsterSquare } from "./MonsterSquare";
+
+/**
+ * Represents a monster card (deck and in play).
+ * assignedRoomIndex: -1 if not assigned to a room, else room index.
+ * ownerSessionId: "" if not claimed, else sessionId of owning player.
+ */
+export class MonsterCard extends Schema {
+  @type("string") id: string = "";
+  @type("string") name: string = "";
+  @type("number") width: number = 0;
+  @type("number") height: number = 0;
+  @type([MonsterSquare]) squares = new ArraySchema<MonsterSquare>();
+  @type("number") assignedRoomIndex: number = -1;
+  @type("string") ownerSessionId: string = "";
+
+  constructor(
+    id = "",
+    name = "",
+    width = 0,
+    height = 0,
+    filledCoords: Array<[number, number]> = []
+  ) {
+    super();
+    this.id = id;
+    this.name = name;
+    this.width = width;
+    this.height = height;
+    // Fill squares array: row-major order (y*width + x)
+    const filledSet = new Set(filledCoords.map(([x, y]) => `${x},${y}`));
+    for (let y = 0; y &lt; height; y++) {
+      for (let x = 0; x &lt; width; x++) {
+        const filled = filledSet.has(`${x},${y}`);
+        this.squares.push(new MonsterSquare(filled));
+      }
+    }
+    this.assignedRoomIndex = -1;
+    this.ownerSessionId = "";
+  }
+
+  /**
+   * Get square at (x, y) within the monster's grid.
+   * Returns undefined if out of bounds.
+   */
+  getSquare(x: number, y: number): MonsterSquare | undefined {
+    if (
+      x &lt; 0 ||
+      x &gt;= this.width ||
+      y &lt; 0 ||
+      y &gt;= this.height
+    ) return undefined;
+    return this.squares[y * this.width + x];
+  }
+}

--- a/server/src/rooms/schema/MonsterSquare.ts
+++ b/server/src/rooms/schema/MonsterSquare.ts
@@ -1,0 +1,15 @@
+import { Schema, type } from "@colyseus/schema";
+
+/**
+ * Represents a single square in a monster's shape.
+ */
+export class MonsterSquare extends Schema {
+  @type("boolean") filled: boolean = false;
+  @type("boolean") checked: boolean = false;
+
+  constructor(filled = false) {
+    super();
+    this.filled = filled;
+    this.checked = false;
+  }
+}


### PR DESCRIPTION
This pull request implements a monster system for the dungeon game, addressing issue #48. It introduces a monster deck containing five predefined monsters (bat, goblin, rat, troll, slime) with unique square layouts. When a new room is opened, a monster card from the deck is drawn and displayed above the room.

Players can drag a monster to their area and use abilities from their cards to cross off squares on the monster card. However, players cannot cross off squares in a room if a monster is present next to it. This ensures strategic gameplay and adds a new layer of interaction between players and monsters.

---

> This pull request was co-created with Cosine Genie

Original Task: [cross-off-dungeon/fo6riraopbhk](https://cosine.sh/mindisle/cross-off-dungeon/task/fo6riraopbhk)
Author: Jaayden Halko

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a monster system to dungeon rooms, introducing a deck of five unique monsters that block room actions until defeated.

- **New Features**
 - Monsters are drawn and displayed when new rooms open.
 - Players can claim monsters, select squares to attack, and defeat them by crossing off all filled squares.
 - Room squares cannot be crossed off if a monster is present.

<!-- End of auto-generated description by cubic. -->

